### PR TITLE
Update checkout tool

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v6.0.2
     - name: Check if branch exists
       id: check-branch-exists
       run: |


### PR DESCRIPTION
Bumped actions/checkout to v6 because [beginning on June 2nd, 2026, runners will begin using Node24 by default.](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
, and my workflows have been throwing warnings